### PR TITLE
Set default zipcode on error

### DIFF
--- a/src/app/hooks/useUserZipCodeOrDefault.tsx
+++ b/src/app/hooks/useUserZipCodeOrDefault.tsx
@@ -24,7 +24,10 @@ export function useUserZipCodeOrDefault(defaultValue: string) {
           position.coords.longitude
         )
           .then(({ zipcode }) => setZipcode(zipcode))
-          .catch((e) => console.error(e))
+          .catch((e) => {
+            console.error("Failed to fetch zip code", e);
+            setZipcode(defaultValue);
+          })
           .finally(() => setIsLoading(false));
       });
     }


### PR DESCRIPTION
- Pi was broken after encountering 403 error from google location API
- Use default zip code if error encountered to fix at least on hard-coded zip code
- 